### PR TITLE
Handle Docstrings With Delimiters On Separate Lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+*.py[cod]
+
+# C extensions
+*.so
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+lib
+lib64
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+nosetests.xml
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Mac OS X
+.DS_Store
+

--- a/src/doxypy.py
+++ b/src/doxypy.py
@@ -21,7 +21,8 @@ __website__ = "http://code.foosel.org/doxypy"
 
 __author__ = (
 	"Philippe 'demod' Neumann (doxypy at demod dot org)",
-	"Gina 'foosel' Haeussge (gina at foosel dot net)" 
+	"Gina 'foosel' Haeussge (gina at foosel dot net)"
+
 )
 
 __licenseName__ = "GPL v2"
@@ -46,35 +47,36 @@ from optparse import OptionParser, OptionGroup
 
 class FSM(object):
 	"""Implements a finite state machine.
-	
+
 	Transitions are given as 4-tuples, consisting of an origin state, a target
 	state, a condition for the transition (given as a reference to a function
 	which gets called with a given piece of input) and a pointer to a function
-	to be called upon the execution of the given transition. 
+	to be called upon the execution of the given transition.
+
 	"""
-	
+
 	"""
 	@var transitions holds the transitions
 	@var current_state holds the current state
 	@var current_input holds the current input
 	@var current_transition hold the currently active transition
 	"""
-	
+
 	def __init__(self, start_state=None, transitions=[]):
 		self.transitions = transitions
 		self.current_state = start_state
 		self.current_input = None
 		self.current_transition = None
-		
+
 	def setStartState(self, state):
 		self.current_state = state
 
 	def addTransition(self, from_state, to_state, condition, callback):
 		self.transitions.append([from_state, to_state, condition, callback])
-		
+
 	def makeTransition(self, input):
 		"""Makes a transition based on the given input.
-		
+
 		@param	input	input to parse by the FSM
 		"""
 		for transition in self.transitions:
@@ -93,16 +95,16 @@ class FSM(object):
 class Doxypy(object):
 	def __init__(self):
 		string_prefixes = "[uU]?[rR]?"
-		
+
 		self.start_single_comment_re = re.compile("^\s*%s(''')" % string_prefixes)
 		self.end_single_comment_re = re.compile("(''')\s*$")
-		
+
 		self.start_double_comment_re = re.compile("^\s*%s(\"\"\")" % string_prefixes)
 		self.end_double_comment_re = re.compile("(\"\"\")\s*$")
-		
+
 		self.single_comment_re = re.compile("^\s*%s(''').*(''')\s*$" % string_prefixes)
 		self.double_comment_re = re.compile("^\s*%s(\"\"\").*(\"\"\")\s*$" % string_prefixes)
-		
+
 		self.defclass_re = re.compile("^(\s*)(def .+:|class .+:)")
 		self.empty_re = re.compile("^\s*$")
 		self.hashline_re = re.compile("^\s*#.*$")
@@ -110,16 +112,16 @@ class Doxypy(object):
 
 		self.multiline_defclass_start_re = re.compile("^(\s*)(def|class)(\s.*)?$")
 		self.multiline_defclass_end_re = re.compile(":\s*$")
-		
+
 		## Transition list format
 		#  ["FROM", "TO", condition, action]
 		transitions = [
 			### FILEHEAD
-			
+
 			# single line comments
 			["FILEHEAD", "FILEHEAD", self.single_comment_re.search, self.appendCommentLine],
 			["FILEHEAD", "FILEHEAD", self.double_comment_re.search, self.appendCommentLine],
-			
+
 			# multiline comments
 			["FILEHEAD", "FILEHEAD_COMMENT_SINGLE", self.start_single_comment_re.search, self.appendCommentLine],
 			["FILEHEAD_COMMENT_SINGLE", "FILEHEAD", self.end_single_comment_re.search, self.appendCommentLine],
@@ -127,21 +129,22 @@ class Doxypy(object):
 			["FILEHEAD", "FILEHEAD_COMMENT_DOUBLE", self.start_double_comment_re.search, self.appendCommentLine],
 			["FILEHEAD_COMMENT_DOUBLE", "FILEHEAD", self.end_double_comment_re.search, self.appendCommentLine],
 			["FILEHEAD_COMMENT_DOUBLE", "FILEHEAD_COMMENT_DOUBLE", self.catchall, self.appendCommentLine],
-			
+
 			# other lines
 			["FILEHEAD", "FILEHEAD", self.empty_re.search, self.appendFileheadLine],
 			["FILEHEAD", "FILEHEAD", self.hashline_re.search, self.appendFileheadLine],
 			["FILEHEAD", "FILEHEAD", self.importline_re.search, self.appendFileheadLine],
 			["FILEHEAD", "DEFCLASS", self.defclass_re.search, self.resetCommentSearch],
-			["FILEHEAD", "DEFCLASS_MULTI", self.multiline_defclass_start_re.search, self.resetCommentSearch],			
+			["FILEHEAD", "DEFCLASS_MULTI", self.multiline_defclass_start_re.search, self.resetCommentSearch],
+
 			["FILEHEAD", "DEFCLASS_BODY", self.catchall, self.appendFileheadLine],
 
 			### DEFCLASS
-			
+
 			# single line comments
 			["DEFCLASS", "DEFCLASS_BODY", self.single_comment_re.search, self.appendCommentLine],
 			["DEFCLASS", "DEFCLASS_BODY", self.double_comment_re.search, self.appendCommentLine],
-			
+
 			# multiline comments
 			["DEFCLASS", "COMMENT_SINGLE", self.start_single_comment_re.search, self.appendCommentLine],
 			["COMMENT_SINGLE", "DEFCLASS_BODY", self.end_single_comment_re.search, self.appendCommentLine],
@@ -155,9 +158,9 @@ class Doxypy(object):
 			["DEFCLASS", "DEFCLASS", self.defclass_re.search, self.resetCommentSearch],
 			["DEFCLASS", "DEFCLASS_MULTI", self.multiline_defclass_start_re.search, self.resetCommentSearch],
 			["DEFCLASS", "DEFCLASS_BODY", self.catchall, self.stopCommentSearch],
-			
+
 			### DEFCLASS_BODY
-			
+
 			["DEFCLASS_BODY", "DEFCLASS", self.defclass_re.search, self.startCommentSearch],
 			["DEFCLASS_BODY", "DEFCLASS_MULTI", self.multiline_defclass_start_re.search, self.startCommentSearch],
 			["DEFCLASS_BODY", "DEFCLASS_BODY", self.catchall, self.appendNormalLine],
@@ -166,10 +169,10 @@ class Doxypy(object):
 			["DEFCLASS_MULTI", "DEFCLASS", self.multiline_defclass_end_re.search, self.appendDefclassLine],
 			["DEFCLASS_MULTI", "DEFCLASS_MULTI", self.catchall, self.appendDefclassLine],
 		]
-		
+
 		self.fsm = FSM("FILEHEAD", transitions)
 		self.outstream = sys.stdout
-		
+
 		self.output = []
 		self.comment = []
 		self.filehead = []
@@ -178,22 +181,24 @@ class Doxypy(object):
 
 	def __closeComment(self):
 		"""Appends any open comment block and triggering block to the output."""
-		
+
 		if options.autobrief:
+			while len(self.comment) > 0 and self.comment[0].strip() == '':
+				del self.comment[0]
 			if len(self.comment) == 1 \
-			or (len(self.comment) > 2 and self.comment[1].strip() == ''):
+			or (len(self.comment) >= 2 and self.comment[1].strip() == ''):
 				self.comment[0] = self.__docstringSummaryToBrief(self.comment[0])
-			
+
 		if self.comment:
 			block = self.makeCommentBlock()
 			self.output.extend(block)
-			
+
 		if self.defclass:
 			self.output.extend(self.defclass)
 
 	def __docstringSummaryToBrief(self, line):
 		"""Adds \\brief to the docstrings summary line.
-		
+
 		A \\brief is prepended, provided no other doxygen command is at the
 		start of the line.
 		"""
@@ -202,7 +207,7 @@ class Doxypy(object):
 			return "\\brief " + line
 		else:
 			return line
-	
+
 	def __flushBuffer(self):
 		"""Flushes the current outputbuffer to the outstream."""
 		if self.output:
@@ -212,8 +217,10 @@ class Doxypy(object):
 				print >>self.outstream, "\n".join(self.output)
 				self.outstream.flush()
 			except IOError:
-				# Fix for FS#33. Catches "broken pipe" when doxygen closes 
-				# stdout prematurely upon usage of INPUT_FILTER, INLINE_SOURCES 
+				# Fix for FS#33. Catches "broken pipe" when doxygen closes
+
+				# stdout prematurely upon usage of INPUT_FILTER, INLINE_SOURCES
+
 				# and FILTER_SOURCE_FILES.
 				pass
 		self.output = []
@@ -221,20 +228,21 @@ class Doxypy(object):
 	def catchall(self, input):
 		"""The catchall-condition, always returns true."""
 		return True
-	
+
 	def resetCommentSearch(self, match):
 		"""Restarts a new comment search for a different triggering line.
-		
+
 		Closes the current commentblock and starts a new comment search.
 		"""
 		if options.debug:
-			print >>sys.stderr, "# CALLBACK: resetCommentSearch" 
+			print >>sys.stderr, "# CALLBACK: resetCommentSearch"
+
 		self.__closeComment()
 		self.startCommentSearch(match)
-	
+
 	def startCommentSearch(self, match):
 		"""Starts a new comment search.
-		
+
 		Saves the triggering line, resets the current comment and saves
 		the current indentation.
 		"""
@@ -243,48 +251,52 @@ class Doxypy(object):
 		self.defclass = [self.fsm.current_input]
 		self.comment = []
 		self.indent = match.group(1)
-	
+
 	def stopCommentSearch(self, match):
 		"""Stops a comment search.
-		
+
 		Closes the current commentblock, resets	the triggering line and
 		appends the current line to the output.
 		"""
 		if options.debug:
-			print >>sys.stderr, "# CALLBACK: stopCommentSearch" 
+			print >>sys.stderr, "# CALLBACK: stopCommentSearch"
+
 		self.__closeComment()
-		
+
 		self.defclass = []
 		self.output.append(self.fsm.current_input)
-	
+
 	def appendFileheadLine(self, match):
 		"""Appends a line in the FILEHEAD state.
-		
+
 		Closes the open comment	block, resets it and appends the current line.
-		""" 
+		"""
+
 		if options.debug:
-			print >>sys.stderr, "# CALLBACK: appendFileheadLine" 
+			print >>sys.stderr, "# CALLBACK: appendFileheadLine"
+
 		self.__closeComment()
 		self.comment = []
 		self.output.append(self.fsm.current_input)
 
 	def appendCommentLine(self, match):
 		"""Appends a comment line.
-		
+
 		The comment delimiter is removed from multiline start and ends as
 		well as singleline comments.
 		"""
 		if options.debug:
-			print >>sys.stderr, "# CALLBACK: appendCommentLine" 
+			print >>sys.stderr, "# CALLBACK: appendCommentLine"
+
 		(from_state, to_state, condition, callback) = self.fsm.current_transition
-		
+
 		# single line comment
 		if (from_state == "DEFCLASS" and to_state == "DEFCLASS_BODY") \
 		or (from_state == "FILEHEAD" and to_state == "FILEHEAD"):
 			# remove comment delimiter from begin and end of the line
 			activeCommentDelim = match.group(1)
 			line = self.fsm.current_input
-			self.comment.append(line[line.find(activeCommentDelim)+len(activeCommentDelim):line.rfind(activeCommentDelim)])
+			self.comment.append(line[line.find(activeCommentDelim)+len(activeCommentDelim):line.rfind(activeCommentDelim)].rstrip())
 
 			if (to_state == "DEFCLASS_BODY"):
 				self.__closeComment()
@@ -300,7 +312,7 @@ class Doxypy(object):
 			# remove comment delimiter from end of the line
 			activeCommentDelim = match.group(1)
 			line = self.fsm.current_input
-			self.comment.append(line[0:line.rfind(activeCommentDelim)])
+			self.comment.append(line[0:line.rfind(activeCommentDelim)].rstrip())
 			if (to_state == "DEFCLASS_BODY"):
 				self.__closeComment()
 				self.defclass = []
@@ -308,19 +320,21 @@ class Doxypy(object):
 		else:
 			# just append the comment line
 			self.comment.append(self.fsm.current_input)
-	
+
 	def appendNormalLine(self, match):
 		"""Appends a line to the output."""
 		if options.debug:
-			print >>sys.stderr, "# CALLBACK: appendNormalLine" 
+			print >>sys.stderr, "# CALLBACK: appendNormalLine"
+
 		self.output.append(self.fsm.current_input)
-		
+
 	def appendDefclassLine(self, match):
 		"""Appends a line to the triggering block."""
 		if options.debug:
-			print >>sys.stderr, "# CALLBACK: appendDefclassLine" 
+			print >>sys.stderr, "# CALLBACK: appendDefclassLine"
+
 		self.defclass.append(self.fsm.current_input)
-	
+
 	def makeCommentBlock(self):
 		"""Indents the current comment block with respect to the current
 		indentation level.
@@ -329,59 +343,61 @@ class Doxypy(object):
 		"""
 		doxyStart = "##"
 		commentLines = self.comment
-		
+
 		commentLines = map(lambda x: "%s# %s" % (self.indent, x), commentLines)
 		l = [self.indent + doxyStart]
 		l.extend(commentLines)
-			 
+
 		return l
-	
+
 	def parse(self, input):
 		"""Parses a python file given as input string and returns the doxygen-
 		compatible representation.
-		
+
 		@param	input	the python code to parse
 		@returns the modified python code
-		""" 
+		"""
+
 		lines = input.split("\n")
-		
+
 		for line in lines:
 			self.fsm.makeTransition(line)
-			
+
 		if self.fsm.current_state == "DEFCLASS":
 			self.__closeComment()
-		
+
 		return "\n".join(self.output)
-	
+
 	def parseFile(self, filename):
 		"""Parses a python file given as input string and returns the doxygen-
 		compatible representation.
-		
+
 		@param	input	the python code to parse
 		@returns the modified python code
-		""" 
+		"""
+
 		f = open(filename, 'r')
-		
+
 		for line in f:
 			self.parseLine(line.rstrip('\r\n'))
 		if self.fsm.current_state == "DEFCLASS":
 			self.__closeComment()
 			self.__flushBuffer()
 		f.close()
-	
+
 	def parseLine(self, line):
-		"""Parse one line of python and flush the resulting output to the 
+		"""Parse one line of python and flush the resulting output to the
 		outstream.
-		
+
 		@param	line	the python code line to parse
 		"""
 		self.fsm.makeTransition(line)
 		self.__flushBuffer()
-	
+
 def optParse():
 	"""Parses commandline options."""
 	parser = OptionParser(prog=__applicationName__, version="%prog " + __version__)
-	
+
 	parser.set_usage("%prog [options] filename")
 	parser.add_option("--autobrief",
 		action="store_true", dest="autobrief",
@@ -391,19 +407,20 @@ def optParse():
 		action="store_true", dest="debug",
 		help="enable debug output on stderr"
 	)
-	
+
 	## parse options
 	global options
 	(options, filename) = parser.parse_args()
-	
+
 	if not filename:
 		print >>sys.stderr, "No filename given."
 		sys.exit(-1)
-	
+
 	return filename[0]
 
 def main():
-	"""Starts the parser on the file given by the filename as the first 
+	"""Starts the parser on the file given by the filename as the first
+
 	argument on the commandline.
 	"""
 	filename = optParse()

--- a/src/doxypy.py
+++ b/src/doxypy.py
@@ -146,7 +146,6 @@ class Doxypy(object):
 			["FILEHEAD", "FILEHEAD", self.importline_re.search, self.appendFileheadLine],
 			["FILEHEAD", "DEFCLASS", self.defclass_re.search, self.resetCommentSearch],
 			["FILEHEAD", "DEFCLASS_MULTI", self.multiline_defclass_start_re.search, self.resetCommentSearch],
-
 			["FILEHEAD", "DEFCLASS_BODY", self.catchall, self.appendFileheadLine],
 
 			### DEFCLASS
@@ -228,9 +227,7 @@ class Doxypy(object):
 				self.outstream.flush()
 			except IOError:
 				# Fix for FS#33. Catches "broken pipe" when doxygen closes
-
 				# stdout prematurely upon usage of INPUT_FILTER, INLINE_SOURCES
-
 				# and FILTER_SOURCE_FILES.
 				pass
 		self.output = []

--- a/test/src/test.py
+++ b/test/src/test.py
@@ -120,6 +120,19 @@ def test9():
 def test10():
 	""" Blub ''' and the same reverse """
 	
+def test11():
+	"""
+	Short docstring sandwich.
+	"""
+	
+def test12():
+	"""
+	Long docstring sandwich.
+
+	Here we've got more lines beyond the
+	initial brief.
+	"""
+	
 class Fnord:
 
 	def __init__(self,


### PR DESCRIPTION
This change is fairly minor but can make a huge difference for projects that format docstrings like so:

```
"""
Here is the brief.

Here is the long description.
It's got multiple lines.
"""
```

Now it'll properly identify the brief when the `autobrief` option is enabled.

Most of the debug output has also been factored out into a single decorator that reduces some duplication and overall lines of code.
